### PR TITLE
Fix projection retrieval for findByUuid

### DIFF
--- a/src/main/java/com/example/demo/repository/AlunoRepository.java
+++ b/src/main/java/com/example/demo/repository/AlunoRepository.java
@@ -12,6 +12,8 @@ import com.example.demo.domain.model.Aluno;
 @Repository
 public interface AlunoRepository extends BaseRepository<Aluno, Long> {
 
+    <T> Optional<T> findByUuid(UUID uuid, Class<T> projectionClass);
+
     // @Query(value = """
     // SELECT EXISTS(
     //     SELECT 1

--- a/src/main/java/com/example/demo/repository/ProfessorRepository.java
+++ b/src/main/java/com/example/demo/repository/ProfessorRepository.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 
 public interface ProfessorRepository extends BaseRepository<Professor, Long> {
 
+    <T> Optional<T> findByUuid(UUID uuid, Class<T> projectionClass);
+
     boolean existsByEmail(String email);
 
     Optional<Professor> findByUuid(UUID uuid);

--- a/src/main/java/com/example/demo/repository/UsuarioRepository.java
+++ b/src/main/java/com/example/demo/repository/UsuarioRepository.java
@@ -16,6 +16,8 @@ import com.example.demo.dto.projection.usuario.UsuarioFull;
 
 @Repository
 public interface UsuarioRepository extends BaseRepository<Usuario, Long> {
+
+    <T> Optional<T> findByUuid(UUID uuid, Class<T> projectionClass);
  
     /* Utilizado para o login */
     @Query("SELECT u FROM Usuario u LEFT JOIN FETCH u.escola WHERE u.email = :email and u.status = 'ATIVO'")

--- a/src/main/java/com/example/demo/service/AlunoService.java
+++ b/src/main/java/com/example/demo/service/AlunoService.java
@@ -152,10 +152,9 @@ public class AlunoService {
     }
 
     public <T> T findByUuid(UUID uuid, Class<T> clazz) {
-        Object usuario = this.alunoRepository.findByUuid(uuid).orElseThrow(
-                () -> new EntityNotFoundException("Aluno não encontrado"));
-
-        return clazz.cast(usuario);
+        return this.alunoRepository
+                .findByUuid(uuid, clazz)
+                .orElseThrow(() -> new EntityNotFoundException("Aluno não encontrado"));
     }
 
     public void changeStudentStatus(UUID uuid, Status status) {

--- a/src/main/java/com/example/demo/service/ProfessorService.java
+++ b/src/main/java/com/example/demo/service/ProfessorService.java
@@ -136,10 +136,9 @@ public class ProfessorService {
 
 
     public <T> T findByUuid(UUID uuid, Class<T> clazz) {
-        Object usuario = this.professorRepository.findByUuid(uuid).orElseThrow(
-                () -> new EntityNotFoundException("Professor não encontrado"));
-
-        return clazz.cast(usuario);
+        return this.professorRepository
+                .findByUuid(uuid, clazz)
+                .orElseThrow(() -> new EntityNotFoundException("Professor não encontrado"));
     }
 
     public void changeStudentStatus(UUID uuid, Status status) {

--- a/src/main/java/com/example/demo/service/UsuarioService.java
+++ b/src/main/java/com/example/demo/service/UsuarioService.java
@@ -160,11 +160,9 @@ public class UsuarioService {
      * @return
      */
     public <T> T findByUuid(UUID uuid, Class<T> clazz) {
-
-        Object usuario = this.usuarioRepository.findByUuid(uuid).orElseThrow(
-                () -> EurekaException.ofNotFound("Usuario não encontrado."));
-
-        return clazz.cast(usuario);
+        return this.usuarioRepository
+                .findByUuid(uuid, clazz)
+                .orElseThrow(() -> EurekaException.ofNotFound("Usuario não encontrado."));
     }
 
     public Optional<UsuarioFull> findByEscolaIdAndPerfil(UUID escolaId, Perfil perfil) {


### PR DESCRIPTION
## Summary
- add generic `findByUuid` projection methods to repository interfaces
- use repository projection in service layer instead of casting

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a100255b483278259fe8c604dd1e1