### PR TITLE
Fix typos in controller annotations

### DIFF
--- a/src/main/java/com/example/demo/controller/AlunoController.java
+++ b/src/main/java/com/example/demo/controller/AlunoController.java
@@ -51,7 +51,7 @@ public class AlunoController {
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','FUNCIONARIO')")
     @EurekaApiOperation(
             summary = "Criar um aluno",
-            description = "Cria e persiste um novo aluno contendo as informações especificadas na requisião."
+            description = "Cria e persiste um novo aluno contendo as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<UUID>> create(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -69,7 +69,7 @@ public class AlunoController {
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','FUNCIONARIO','RESPONSAVEL','ALUNO')")
     @EurekaApiOperation(
             summary = "Atualizar um aluno",
-            description = "Atualiza, a partir do seu UUID, um aluno persistido com as informações especificadas na requisião."
+            description = "Atualiza, a partir do seu UUID, um aluno persistido com as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<String>> update(
             @Parameter(description = "UUID do aluno a ser atualizado", required = true)

--- a/src/main/java/com/example/demo/controller/CategoriaController.java
+++ b/src/main/java/com/example/demo/controller/CategoriaController.java
@@ -37,7 +37,7 @@ public class CategoriaController {
     @PreAuthorize("hasAnyRole('ADMIN', 'FUNCIONARIO')")
     @EurekaApiOperation(
             summary = "Criar uma categoria",
-            description = "Cria e persiste uma nova categoria contendo as informações especificadas na requisião."
+            description = "Cria e persiste uma nova categoria contendo as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<String>> criarCategoria(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -54,7 +54,7 @@ public class CategoriaController {
     @PreAuthorize("hasRole('MASTER')")
     @EurekaApiOperation(
             summary = "Atualizar uma categoria",
-            description = "Atualiza, a partir do seu UUID, uma categoria persistida com as informações especificadas na requisião."
+            description = "Atualiza, a partir do seu UUID, uma categoria persistida com as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<String>> atualizarCategoria(
             @Parameter(description = "UUID da categoria a ser atualizada", required = true)

--- a/src/main/java/com/example/demo/controller/EscolaController.java
+++ b/src/main/java/com/example/demo/controller/EscolaController.java
@@ -79,7 +79,7 @@ public class EscolaController {
     @PreAuthorize("hasRole('MASTER')")
     @EurekaApiOperation(
             summary = "Criar uma escola",
-            description = "Cria e persiste uma nova escola contendo as informações especificadas na requisião."
+            description = "Cria e persiste uma nova escola contendo as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<String>> criarEscola(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -109,7 +109,7 @@ public class EscolaController {
     @PreAuthorize("hasRole('MASTER')")
     @EurekaApiOperation(
             summary = "Atualizar uma escola",
-            description = "Atualiza, a partir do seu UUID, uma escola persistida com as informações especificadas na requisião."
+            description = "Atualiza, a partir do seu UUID, uma escola persistida com as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<String>> atualizarEscola(
             @Parameter(description = "UUID da escola a ser buscada", required = true)
@@ -226,7 +226,7 @@ public class EscolaController {
 //    @PutMapping("params/{uuid}")
 //    @EurekaApiOperation(
 //            summary = "Atualizar os parametros de uma escola",
-//            description = "Atualiza, a partir do seu UUID, os parametros de uma escola persistida com as informações especificadas na requisião."
+//            description = "Atualiza, a partir do seu UUID, os parametros de uma escola persistida com as informações especificadas na requisição."
 //    )
 //    public ResponseEntity<ApiReturn<String>> atualizarParametrosEscola(
 //            @Parameter(description = "UUID da escola a ser buscada", required = true)

--- a/src/main/java/com/example/demo/controller/ProdutoController.java
+++ b/src/main/java/com/example/demo/controller/ProdutoController.java
@@ -34,7 +34,7 @@ public class ProdutoController {
     @PreAuthorize("hasAnyRole('ADMIN', 'PDV')")
     @EurekaApiOperation(
             summary = "Criar um produto",
-            description = "Cria e persiste um novo produto contendo as informações especificadas na requisião."
+            description = "Cria e persiste um novo produto contendo as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<String>> criarProduto(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -51,7 +51,7 @@ public class ProdutoController {
     @PreAuthorize("hasRole('ADMIN')")
     @EurekaApiOperation(
             summary = "Atualizar um produto",
-            description = "Atualiza, a partir do seu UUID, um produto persistido com as informações especificadas na requisião."
+            description = "Atualiza, a partir do seu UUID, um produto persistido com as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<String>> atualizarProduto(
             @Parameter(description = "UUID do produto a ser atualizado", required = true)

--- a/src/main/java/com/example/demo/controller/ProfessorController.java
+++ b/src/main/java/com/example/demo/controller/ProfessorController.java
@@ -38,7 +38,7 @@ public class ProfessorController {
         @PreAuthorize("hasAnyRole('MASTER','ADMIN','FUNCIONARIO')")
         @EurekaApiOperation(
                 summary = "Criar um professor",
-                description = "Cria e persiste um novo professor contendo as informações especificadas na requisião."
+                description = "Cria e persiste um novo professor contendo as informações especificadas na requisição."
         )
         public ResponseEntity<ApiReturn<UUID>> create(
                 @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -56,7 +56,7 @@ public class ProfessorController {
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','FUNCIONARIO','RESPONSAVEL','PROFESSOR')")
     @EurekaApiOperation(
             summary = "Atualizar um professor",
-            description = "Atualiza, a partir do seu UUID, um professor persistido com as informações especificadas na requisião."
+            description = "Atualiza, a partir do seu UUID, um professor persistido com as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<String>> update(
             @Parameter(description = "UUID do professor a ser atualizado", required = true)

--- a/src/main/java/com/example/demo/controller/UsuarioController.java
+++ b/src/main/java/com/example/demo/controller/UsuarioController.java
@@ -50,7 +50,7 @@ public class UsuarioController {
     @PreAuthorize("hasAnyRole('MASTER','ADMIN','FUNCIONARIO')")
     @EurekaApiOperation(
             summary = "Criar um usuário",
-            description = "Cria e persiste um novo usuário contendo as informações especificadas na requisião."
+            description = "Cria e persiste um novo usuário contendo as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<UUID>> create(
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -67,7 +67,7 @@ public class UsuarioController {
     @CheckAccess(entity = EntityNames.USUARIO)
     @EurekaApiOperation(
             summary = "Atualizar um usuário",
-            description = "Atualiza, a partir do seu UUID, um usuário persistido com as informações especificadas na requisião."
+            description = "Atualiza, a partir do seu UUID, um usuário persistido com as informações especificadas na requisição."
     )
     public ResponseEntity<ApiReturn<String>> update(
             @Parameter(description = "UUID do usuário a ser atualizado", required = true)


### PR DESCRIPTION
## Summary
- fix typo `requisião` to `requisição` in controller descriptions and request-body annotations

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1279aabc8327a4f7ec643c2c6629